### PR TITLE
2018.3で動作するようにビルドスクリプトを変更

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
 
 intellij {
-    version '2018.2'
+    version '2018.3'
     plugins = ['Kotlin']
     pluginName 'kotlin-fill-class'
     publishPlugin {


### PR DESCRIPTION
`./gradlew buildPlugin`で2018.3ローカルインストールできるところまでは確認しました。
ただし、他のバージョンなどでは未確認です。intelliJ Pluginの動作がいまいちわかっていないので検討違いな修正であればRejectしてください。