### PR TITLE
Introduce options

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,10 +21,13 @@
     <depends>org.jetbrains.kotlin</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <intentionAction>
-            <className>com.github.suusan2go.kotlinfillclass.intentions.FillClassIntention</className>
-            <category>Kotlin</category>
-        </intentionAction>
+        <localInspection implementationClass="com.github.suusan2go.kotlinfillclass.inspections.FillClassInspection"
+                         groupPath="Kotlin"
+                         groupName="Fill class"
+                         enabledByDefault="true"
+                         level="INFORMATION"
+                         language="kotlin"
+                         displayName="Fill class" />
     </extensions>
 
     <application-components>

--- a/src/main/resources/inspectionDescriptions/FillClass.html
+++ b/src/main/resources/inspectionDescriptions/FillClass.html
@@ -1,0 +1,1 @@
+This inspection actions for empty constructor or function to fill property with default value.

--- a/src/main/resources/intentionDescriptions/FillClassIntention/after.kt.template
+++ b/src/main/resources/intentionDescriptions/FillClassIntention/after.kt.template
@@ -1,5 +1,0 @@
-data class User(val id: Int, val name: String, val email: String)
-
-fun foo() {
-    User<spot>(id = 0, name = "", email = "")</spot>
-}

--- a/src/main/resources/intentionDescriptions/FillClassIntention/before.kt.template
+++ b/src/main/resources/intentionDescriptions/FillClassIntention/before.kt.template
@@ -1,5 +1,0 @@
-data class User(val id: Int, val name: String, val email: String)
-
-fun foo() {
-    User<spot>()</spot>
-}

--- a/src/main/resources/intentionDescriptions/FillClassIntention/description.html
+++ b/src/main/resources/intentionDescriptions/FillClassIntention/description.html
@@ -1,5 +1,0 @@
-<html>
-<body>
-This intention fill the constructor call with default value.
-</body>
-</html>

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspectionTest.kt
@@ -173,16 +173,31 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         """, withoutDefaultValues = true)
     }
 
+    fun `test do not fill default arguments`() {
+        doAvailableTest("""
+            class User(val name: String, val age: Int = 0)
+            fun test() {
+                User(<caret>)
+            }
+        """, """
+            class User(val name: String, val age: Int = 0)
+            fun test() {
+                User(name = "")
+            }
+        """, withoutDefaultArguments = true)
+    }
+
     private fun doAvailableTest(
         before: String,
         after: String,
         problemDescription: String = "Fill class constructor",
         dependencies: List<String> = emptyList(),
         javaDependencies: List<String> = emptyList(),
-        withoutDefaultValues: Boolean = false
+        withoutDefaultValues: Boolean = false,
+        withoutDefaultArguments: Boolean = false
     ) {
         val highlightInfo = doHighlighting(
-            before, problemDescription, dependencies, javaDependencies, withoutDefaultValues
+            before, problemDescription, dependencies, javaDependencies, withoutDefaultValues, withoutDefaultArguments
         )
         check(highlightInfo != null) { "Problems should be detected at caret" }
         myFixture.launchAction(myFixture.findSingleIntention(problemDescription))
@@ -194,10 +209,11 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         problemDescription: String = "Fill class constructor",
         dependencies: List<String> = emptyList(),
         javaDependencies: List<String> = emptyList(),
-        withoutDefaultValues: Boolean = false
+        withoutDefaultValues: Boolean = false,
+        withoutDefaultArguments: Boolean = false
     ) {
         val highlightInfo = doHighlighting(
-            before, problemDescription, dependencies, javaDependencies, withoutDefaultValues
+            before, problemDescription, dependencies, javaDependencies, withoutDefaultValues, withoutDefaultArguments
         )
         check(highlightInfo == null) { "No problems should be detected at caret" }
     }
@@ -205,9 +221,10 @@ class FillClassInspectionTest : BasePlatformTestCase() {
     private fun doHighlighting(
         code: String,
         problemDescription: String = "Fill class constructor",
-        dependencies: List<String> = emptyList(),
-        javaDependencies: List<String> = emptyList(),
-        withoutDefaultValues: Boolean = false
+        dependencies: List<String>,
+        javaDependencies: List<String>,
+        withoutDefaultValues: Boolean,
+        withoutDefaultArguments: Boolean
     ): HighlightInfo? {
         check("<caret>" in code) { "Please, add `<caret>` marker to\n$code" }
 
@@ -220,7 +237,8 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         myFixture.configureByText(KotlinFileType.INSTANCE, code.trimIndent())
 
         val inspection = FillClassInspection(
-            withoutDefaultValues = withoutDefaultValues
+            withoutDefaultValues = withoutDefaultValues,
+            withoutDefaultArguments = withoutDefaultArguments
         )
         myFixture.enableInspections(inspection)
 

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspectionTest.kt
@@ -159,14 +159,31 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         """)
     }
 
+    fun `test fill class constructor without default values`() {
+        doAvailableTest("""
+            class User(val name: String, val age: Int)
+            fun test() {
+                User(<caret>)
+            }
+        """, """
+            class User(val name: String, val age: Int)
+            fun test() {
+                User(name =, age =)
+            }
+        """, withoutDefaultValues = true)
+    }
+
     private fun doAvailableTest(
         before: String,
         after: String,
         problemDescription: String = "Fill class constructor",
         dependencies: List<String> = emptyList(),
-        javaDependencies: List<String> = emptyList()
+        javaDependencies: List<String> = emptyList(),
+        withoutDefaultValues: Boolean = false
     ) {
-        val highlightInfo = doHighlighting(before, problemDescription, dependencies, javaDependencies)
+        val highlightInfo = doHighlighting(
+            before, problemDescription, dependencies, javaDependencies, withoutDefaultValues
+        )
         check(highlightInfo != null) { "Problems should be detected at caret" }
         myFixture.launchAction(myFixture.findSingleIntention(problemDescription))
         myFixture.checkResult(after.trimIndent())
@@ -176,9 +193,12 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         before: String,
         problemDescription: String = "Fill class constructor",
         dependencies: List<String> = emptyList(),
-        javaDependencies: List<String> = emptyList()
+        javaDependencies: List<String> = emptyList(),
+        withoutDefaultValues: Boolean = false
     ) {
-        val highlightInfo = doHighlighting(before, problemDescription, dependencies, javaDependencies)
+        val highlightInfo = doHighlighting(
+            before, problemDescription, dependencies, javaDependencies, withoutDefaultValues
+        )
         check(highlightInfo == null) { "No problems should be detected at caret" }
     }
 
@@ -186,7 +206,8 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         code: String,
         problemDescription: String = "Fill class constructor",
         dependencies: List<String> = emptyList(),
-        javaDependencies: List<String> = emptyList()
+        javaDependencies: List<String> = emptyList(),
+        withoutDefaultValues: Boolean = false
     ): HighlightInfo? {
         check("<caret>" in code) { "Please, add `<caret>` marker to\n$code" }
 
@@ -198,7 +219,9 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         }
         myFixture.configureByText(KotlinFileType.INSTANCE, code.trimIndent())
 
-        val inspection = FillClassInspection()
+        val inspection = FillClassInspection(
+            withoutDefaultValues = withoutDefaultValues
+        )
         myFixture.enableInspections(inspection)
 
         val inspectionProfileManager = ProjectInspectionProfileManager.getInstance(project)


### PR DESCRIPTION
Fixes #48 

Added options to inspection profile setting
<img width="829" alt="スクリーンショット 2021-02-11 20 27 29" src="https://user-images.githubusercontent.com/1121855/107631811-f4a9b400-6ca8-11eb-9ea8-1b0b56f0fda9.png">

Fixes #47: `Fill arguments without default values`
<img width="503" alt="スクリーンショット 2021-02-11 20 29 07" src="https://user-images.githubusercontent.com/1121855/107631816-f5dae100-6ca8-11eb-9871-0e0c924f2fbf.png">
<img width="732" alt="スクリーンショット 2021-02-11 20 29 41" src="https://user-images.githubusercontent.com/1121855/107631823-f6737780-6ca8-11eb-9c7e-5b94459eb194.png">

Fixed #41: `Do not fill default arguments`
<img width="502" alt="スクリーンショット 2021-02-11 20 29 16" src="https://user-images.githubusercontent.com/1121855/107631826-f83d3b00-6ca8-11eb-9abf-34483b5cf1e8.png">
<img width="707" alt="スクリーンショット 2021-02-11 20 30 00" src="https://user-images.githubusercontent.com/1121855/107631832-f96e6800-6ca8-11eb-94d0-1e1597c17b21.png">
