### PR TITLE
Add IntelliJ v2021.1 as a target for the plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ sourceCompatibility = JavaVersion.VERSION_11
 targetCompatibility = JavaVersion.VERSION_11
 
 intellij {
-    version '2020.3'
+    version '2021.1'
     plugins = ['Kotlin', 'java']
     pluginName 'kotlin-fill-class'
     publishPlugin {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,12 +10,12 @@
     ]]></description>
 
     <change-notes><![CDATA[
-    1.0.5 - Adds support for IntelliJ 2020.3
+    1.0.6 - Adds support for IntelliJ 2021.1
     ]]>
     </change-notes>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="203" until-build="203.*"/>
+    <idea-version since-build="202" until-build="211.*"/>
 
     <depends>com.intellij.modules.lang</depends>
     <depends>org.jetbrains.kotlin</depends>


### PR DESCRIPTION
Apologies if there's insufficient info in the PR, let me know if I can flesh it out further.

Using the original repo as a template, I ran some experiments locally in 2021.1 successfully, therefore an IDEA version upgrade shouldn't harm the original plugin's functionality. I therefore bumped the versions in gradle and the plugin.xml manifest file.

Thank you very much, and let me know if I can be of any help!