### PR TITLE
Add support for older version of IDEA and Android Studio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ intellij {
     publishPlugin {
         token System.getenv('TOKEN')
     }
+    patchPluginXml {
+        sinceBuild '191.8026.42'
+    }
 }
 
 repositories {
@@ -35,7 +38,7 @@ repositories {
 }
 
 group 'com.github.suusan2go.kotlin-fill-class'
-version '1.0.9'
+version '1.0.10'
 
 sourceCompatibility = 11
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,7 +10,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
-    1.0.9 - Add support for filling default value to lambda arguments #53
+    1.0.10 - Add support for older version of IDEA and Android Studio
     ]]>
     </change-notes>
 


### PR DESCRIPTION
closes #54 

Add `patchPluginXml` to support older versions of IDEA and Android studio.
Currently `sinceBuild` and `untilBuild` is overrided by `intellij.version` value according to this doc.
https://plugins.jetbrains.com/docs/intellij/gradle-guide.html#patching-the-plugin-configuration-file