### PR TITLE
Add "Move pointer to every argument" setting

### DIFF
--- a/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspection.kt
+++ b/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspection.kt
@@ -49,7 +49,7 @@ class FillClassInspection(
     @JvmField var withoutDefaultArguments: Boolean = false,
     @JvmField var withTrailingComma: Boolean = false,
     @JvmField var putArgumentsOnSeparateLines: Boolean = false,
-    @JvmField var movePointerToEveryArgument: Boolean = false,
+    @JvmField var movePointerToEveryArgument: Boolean = true,
 ) : AbstractKotlinInspection() {
     override fun buildVisitor(
         holder: ProblemsHolder,

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillClassInspectionTest.kt
@@ -378,6 +378,70 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         )
     }
 
+    fun `test move pointer to every argument`() {
+        doAvailableTest(
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(<caret>)
+        """,
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(x = 0<caret>, y = 0, z = 0)
+        """,
+            problemDescription = "Fill function",
+            movePointerToEveryArgument = true
+        )
+    }
+
+    fun `test move pointer to every argument with existing arguments`() {
+        doAvailableTest(
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(x = 1<caret>)
+        """,
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(x = 1, y = 0<caret>, z = 0)
+        """,
+            problemDescription = "Fill function",
+            movePointerToEveryArgument = true
+        )
+    }
+
+    fun `test move pointer to every argument with putArgumentsOnSeparateLines`() {
+        doAvailableTest(
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(<caret>)
+        """,
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(x = 0<caret>,
+                    y = 0,
+                    z = 0)
+        """,
+            problemDescription = "Fill function",
+            movePointerToEveryArgument = true,
+            putArgumentsOnSeparateLines = true
+        )
+    }
+
+    fun `test move pointer to every argument with withoutDefaultValues`() {
+        doAvailableTest(
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(<caret>)
+        """,
+            """
+            fun foo(x: Int, y: Int, z: Int) = x + y + z
+            val bar = foo(x =<caret>, y =, z =)
+        """,
+            problemDescription = "Fill function",
+            movePointerToEveryArgument = true,
+            withoutDefaultValues = true
+        )
+    }
+
     private fun doAvailableTest(
         before: String,
         after: String,
@@ -388,6 +452,7 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         withoutDefaultArguments: Boolean = false,
         withTrailingComma: Boolean = false,
         putArgumentsOnSeparateLines: Boolean = false,
+        movePointerToEveryArgument: Boolean = false,
     ) {
         val highlightInfo = doHighlighting(
             before,
@@ -398,6 +463,7 @@ class FillClassInspectionTest : BasePlatformTestCase() {
             withoutDefaultArguments,
             withTrailingComma,
             putArgumentsOnSeparateLines,
+            movePointerToEveryArgument,
         )
         check(highlightInfo != null) { "Problems should be detected at caret" }
         myFixture.launchAction(myFixture.findSingleIntention(problemDescription))
@@ -413,6 +479,7 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         withoutDefaultArguments: Boolean = false,
         withTrailingComma: Boolean = false,
         putArgumentsOnSeparateLines: Boolean = false,
+        movePointerToEveryArgument: Boolean = false
     ) {
         val highlightInfo = doHighlighting(
             before,
@@ -423,6 +490,7 @@ class FillClassInspectionTest : BasePlatformTestCase() {
             withoutDefaultArguments,
             withTrailingComma,
             putArgumentsOnSeparateLines,
+            movePointerToEveryArgument,
         )
         check(highlightInfo == null) { "No problems should be detected at caret" }
     }
@@ -436,6 +504,7 @@ class FillClassInspectionTest : BasePlatformTestCase() {
         withoutDefaultArguments: Boolean,
         withTrailingComma: Boolean,
         putArgumentsOnSeparateLines: Boolean,
+        movePointerToEveryArgument: Boolean,
     ): HighlightInfo? {
         check("<caret>" in code) { "Please, add `<caret>` marker to\n$code" }
 
@@ -452,6 +521,7 @@ class FillClassInspectionTest : BasePlatformTestCase() {
             withoutDefaultArguments = withoutDefaultArguments,
             withTrailingComma = withTrailingComma,
             putArgumentsOnSeparateLines = putArgumentsOnSeparateLines,
+            movePointerToEveryArgument = movePointerToEveryArgument,
         )
         myFixture.enableInspections(inspection)
 


### PR DESCRIPTION
Fixes #57 
```kotlin
fun foo(x: Int, y: Int, z: Int) = x + y + z

val bar = foo()
```

<img width="940" alt="スクリーンショット 2022-09-05 16 24 08" src="https://user-images.githubusercontent.com/1121855/188410139-525e99a9-96f4-4b71-a6fb-8dccefd4b732.png">

<img width="504" alt="スクリーンショット 2022-09-05 16 24 23" src="https://user-images.githubusercontent.com/1121855/188410210-69aed830-7f56-4964-9ebb-6316e718a921.png">

↓

<img width="374" alt="スクリーンショット 2022-09-05 16 24 29" src="https://user-images.githubusercontent.com/1121855/188410245-76eb9742-238a-4ff3-9a7b-df16bf8b073f.png">
