### PR TITLE
fix NoSuchMethodError before v2022.3

### DIFF
--- a/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/BaseFillClassInspection.kt
+++ b/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/BaseFillClassInspection.kt
@@ -134,7 +134,7 @@ open class FillClassFix(
         val lambdaArgument = (parent as? KtCallElement)?.lambdaArguments?.singleOrNull()
         val parameterForLambdaArgument = lambdaArgument?.let { resolvedCall?.getParameterForArgument(it) }
 
-        val factory = KtPsiFactory(this)
+        val factory = KtPsiFactory(this.project)
         val needsTrailingComma = withTrailingComma && !hasTrailingComma()
         parameters.forEachIndexed { index, parameter ->
             if (parameter == parameterForLambdaArgument) return@forEachIndexed


### PR DESCRIPTION
When the target IDEA version was upgraded, `KtPsiFactory(KtElement)` now uses a constructor instead of a top-level function.

This constructor did not exist until 2022.3, resulting in a NoSuchMethodError.

Instead, I have changed to use the previously existing `KtPsiFactory(Project)`.

### IDEA 2022.3

https://github.com/JetBrains/kotlin/blob/v1.7.22/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt#L31-L32

### IDEA 2023.1

https://github.com/JetBrains/kotlin/blob/2622e593b544423c6e56137ef513ad533b38c1bd/compiler/psi/src/org/jetbrains/kotlin/psi/KtPsiFactory.kt#L77



close #97 