### PR TITLE
Fill enum value

### DIFF
--- a/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/BaseFillClassInspection.kt
+++ b/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/BaseFillClassInspection.kt
@@ -54,6 +54,7 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode
 import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassDescriptor
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.typeUtil.isEnum
 import org.jetbrains.kotlin.utils.ifEmpty
 
 abstract class BaseFillClassInspection(
@@ -333,6 +334,7 @@ open class FillClassFix(
             KotlinBuiltIns.isSetOrNullableSet(type) -> "setOf()"
             KotlinBuiltIns.isMapOrNullableMap(type) -> "mapOf()"
             type.isFunctionType -> type.lambdaDefaultValue()
+            type.isEnum() -> "${type}.${type.memberScope.getVariableNames().first().identifier}"
             type.isMarkedNullable -> "null"
             else -> null
         }

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillDummyValueInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillDummyValueInspectionTest.kt
@@ -163,7 +163,7 @@ class FillDummyValueInspectionTest : BasePlatformTestCase() {
             }
             class Test(emotion: EmotionType)
             fun test() {
-                Test(emotion = EmotionType.HAPPY)
+                Test(emotion = EmotionType.ANGRY)
             }
         """,
         )

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillDummyValueInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillDummyValueInspectionTest.kt
@@ -146,28 +146,45 @@ class FillDummyValueInspectionTest : BasePlatformTestCase() {
         )
     }
 
-    fun `test don't add default value for enum,abstract,sealed`() {
+    fun `test add default value for enum`() {
         doAvailableTest(
             """
-            enum class A(val a: String) {
-                Foo("foo"), Bar("bar"), Baz("baz");
+            enum class EmotionType(val description: String) {
+                HAPPY("happy"), SAD("sad"), ANGRY("angry");
             }
-            sealed class B(val b: String)
-            abstract class C(val c: String)
-            class Test(a: A, b: B, c: C)
+            class Test(emotion: EmotionType)
             fun test() {
                 Test(<caret>)
             }
         """,
             """
-            enum class A(val a: String) {
-                Foo("foo"), Bar("bar"), Baz("baz");
+            enum class EmotionType(val description: String) {
+                HAPPY("happy"), SAD("sad"), ANGRY("angry");
             }
+            class Test(emotion: EmotionType)
+            fun test() {
+                Test(emotion = EmotionType.HAPPY)
+            }
+        """,
+        )
+    }
+
+    fun `test don't add default value for abstract,sealed`() {
+        doAvailableTest(
+            """
             sealed class B(val b: String)
             abstract class C(val c: String)
-            class Test(a: A, b: B, c: C)
+            class Test(b: B, c: C)
             fun test() {
-                Test(a =, b =, c =)
+                Test(<caret>)
+            }
+        """,
+            """
+            sealed class B(val b: String)
+            abstract class C(val c: String)
+            class Test(b: B, c: C)
+            fun test() {
+                Test(b =, c =)
             }
         """,
         )

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillEmptyValueInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillEmptyValueInspectionTest.kt
@@ -222,7 +222,7 @@ class FillEmptyValueInspectionTest : BasePlatformTestCase() {
             }
             class Test(emotion: EmotionType)
             fun test() {
-                Test(emotion = EmotionType.HAPPY)
+                Test(emotion = EmotionType.ANGRY)
             }
         """,
         )

--- a/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillEmptyValueInspectionTest.kt
+++ b/src/test/kotlin/com/github/suusan2go/kotlinfillclass/inspections/FillEmptyValueInspectionTest.kt
@@ -205,28 +205,45 @@ class FillEmptyValueInspectionTest : BasePlatformTestCase() {
         )
     }
 
-    fun `test don't add default value for enum,abstract,sealed`() {
+    fun `test add default value for enum`() {
         doAvailableTest(
             """
-            enum class A(val a: String) {
-                Foo("foo"), Bar("bar"), Baz("baz");
+            enum class EmotionType(val description: String) {
+                HAPPY("happy"), SAD("sad"), ANGRY("angry");
             }
-            sealed class B(val b: String)
-            abstract class C(val c: String)
-            class Test(a: A, b: B, c: C)
+            class Test(emotion: EmotionType)
             fun test() {
                 Test(<caret>)
             }
         """,
             """
-            enum class A(val a: String) {
-                Foo("foo"), Bar("bar"), Baz("baz");
+            enum class EmotionType(val description: String) {
+                HAPPY("happy"), SAD("sad"), ANGRY("angry");
             }
+            class Test(emotion: EmotionType)
+            fun test() {
+                Test(emotion = EmotionType.HAPPY)
+            }
+        """,
+        )
+    }
+
+    fun `test don't add default value for abstract,sealed`() {
+        doAvailableTest(
+            """
             sealed class B(val b: String)
             abstract class C(val c: String)
-            class Test(a: A, b: B, c: C)
+            class Test(b: B, c: C)
             fun test() {
-                Test(a =, b =, c =)
+                Test(<caret>)
+            }
+        """,
+            """
+            sealed class B(val b: String)
+            abstract class C(val c: String)
+            class Test(b: B, c: C)
+            fun test() {
+                Test(b =, c =)
             }
         """,
         )


### PR DESCRIPTION
It would be nice to fill with enum.
I've seen that enums are intentionally excluded in code. 
but I think working with enum would be very useful.


### Discussion Points
`type.memberScope.getVariableNames()` returns enum members like `HAPPY`, `SAD`, `ANGRY` but also returns `description`(parameter), auto generated variables like `name`, `ordinal`. 

To identify exclusively enum members from them, (1) To filter starting with upper case variable (using convention; enum member name should start with capital) (2) To filter not generated variables(name, ordinal), parameter(in this case - description) 
(3) just leave it to luck to choose enum members on runtime. 

I tried (2) but the code will be too complicated. It's hard to identify parameter from enum members and others. 
I think (1) solution would be reasonable in this situation. 
I want to hear your opinion. @suusan2go @oboenikui

(This draft is applied (1) case)
