### PR TITLE
Replace deprecated partiallyAppliedSymbol with direct call properties

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ intellijPlatform {
         version = pluginVersion
         name = "kotlin-fill-class"
         ideaVersion {
-            sinceBuild = "253"
+            sinceBuild = "261"
             untilBuild = provider { null }
         }
     }
@@ -101,7 +101,7 @@ intellijPlatform {
             select {
                 types = listOf(IntelliJPlatformType.IntellijIdea)
                 channels = listOf(ProductRelease.Channel.RELEASE)
-                sinceBuild = "2025.3.1"
+                sinceBuild = "2026.1"
             }
         }
     }

--- a/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/k2/BaseFillClassInspection.kt
+++ b/src/main/kotlin/com/github/suusan2go/kotlinfillclass/inspections/k2/BaseFillClassInspection.kt
@@ -123,14 +123,14 @@ abstract class BaseFillClassInspection(
         val callElement = element.parent as? KtCallElement ?: return null
         return findCandidates(callElement).takeIf { it.isNotEmpty() }?.let {
             Context(
-                functionName = it[0].partiallyAppliedSymbol.signature.toString(),
+                functionName = it[0].signature.toString(),
                 candidateLabels =
                     it.map { call ->
                         callElement.calleeExpression?.text + (
                             call.symbol.psi
                                 ?.getChildOfType<KtParameterList>()
                                 ?.text
-                                ?: call.partiallyAppliedSymbol.signature.valueParameters.joinToString(
+                                ?: call.signature.valueParameters.joinToString(
                                     prefix = "(",
                                     postfix = ")",
                                     separator = ", ",
@@ -140,7 +140,7 @@ abstract class BaseFillClassInspection(
                                 )
                         )
                     },
-                candidates = it.map { call -> call.partiallyAppliedSymbol.signature.valueParameters },
+                candidates = it.map { call -> call.signature.valueParameters },
                 isConstructor = it[0].symbol is KaConstructorSymbol,
             )
         }
@@ -166,7 +166,7 @@ abstract class BaseFillClassInspection(
                                 KaSymbolOrigin.JAVA_SYNTHETIC_PROPERTY,
                                 KaSymbolOrigin.JS_DYNAMIC,
                             ) &&
-                            ktCall.partiallyAppliedSymbol.signature.valueParameters
+                            ktCall.signature.valueParameters
                                 .filterNot { it.symbol.isVararg }
                                 .size > argumentSize
                     }
@@ -262,7 +262,7 @@ abstract class BaseFillClassInspection(
                         createArguments(
                             element = element,
                             lambdaArgument = lambdaArgument,
-                            parameters = candidates[candidateIndex].partiallyAppliedSymbol.signature.valueParameters,
+                            parameters = candidates[candidateIndex].signature.valueParameters,
                         )
                     } else {
                         null

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,7 +26,7 @@
     </change-notes>
 
     <!-- please see https://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="253"/>
+    <idea-version since-build="261"/>
 
     <depends>com.intellij.modules.lang</depends>
     <depends>com.intellij.modules.java</depends>


### PR DESCRIPTION
## Summary
- Replace deprecated `partiallyAppliedSymbol.signature` usages in `BaseFillClassInspection` with direct `KaFunctionCall.signature` access.
- Raise the minimum supported IDE version from 2025.3 (253) to 2026.1 (261), which bundles Kotlin 2.3.20 where the new Analysis API is available.

## Test plan
- [x] Run `./gradlew build` on Java 21
- [x] Verify K2 inspections still work in IntelliJ IDEA 2026.1+
- [x] Confirm the plugin is not installable on IDEA 2025.3 after the since-build bump