### PR TITLE
release 2.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_21
 }
 
-val pluginVersion = "2.1.1"
+val pluginVersion = "2.2.0"
 
 group = "com.github.suusan2go.kotlin-fill-class"
 version = pluginVersion

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -10,16 +10,13 @@
     ]]></description>
 
     <change-notes><![CDATA[
-      <h2>2.1.1</h2>
+      <h2>2.2.0</h2>
       <ul>
         <li>
-          Fix invalid PSI errors when setting template fields after fill. (related to <a href="https://github.com/suusan2go/kotlin-fill-class/issues/143">#143</a>, <a href="https://github.com/suusan2go/kotlin-fill-class/issues/136">#136</a>)
+          Replace deprecated Analysis API usages with direct call properties.
         </li>
         <li>
-          Remove experimental APIs for improved stability.
-        </li>
-        <li>
-          Bump build toolchain to IntelliJ IDEA 2026.1.3.
+          Bumped minimum supported version to IntelliJ IDEA 2026.1.
         </li>
       </ul>
     ]]>


### PR DESCRIPTION
## Summary
- Bump plugin version to 2.2.0.
- Update change notes for the 2.2.0 release.

## Test plan
- [ ] Merge this PR
- [ ] Run `./gradlew publishPlugin` with `TOKEN` set
- [ ] Create GitHub release tag `2.2.0` after JetBrains approval